### PR TITLE
Fix security alerts

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@nestjs/terminus": "^7.0.1",
     "@nestjs/websockets": "^7.0.7",
     "@typegoose/typegoose": "^6.4.0",
-    "apollo-server-fastify": "^2.12.0",
+    "apollo-server-fastify": "^2.14.2",
     "bcryptjs": "^2.4.3",
     "file-type": "^14.1.4",
     "graphql": "^14.6.0",


### PR DESCRIPTION
Update `apollo-server-fastify` to version `2.14.2` in order to fix the security alerts